### PR TITLE
fix: integrate tokens build into deployment pipeline

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -11,6 +11,7 @@
     "build": "style-dictionary build --config style-dictionary.config.js && tsc",
     "build:brands": "node build-brands.js",
     "build:all": "npm run build && npm run build:brands",
+    "tokens": "npm run build:all",
     "dev": "style-dictionary build --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.js",

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
+    "tokens": {
+      "dependsOn": [],
+      "outputs": ["dist/**"],
+      "cache": false
+    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "tokens"],
       "outputs": ["dist/**", ".next/**", "storybook-static/**"]
     },
     "dev": {


### PR DESCRIPTION
Fixes #2

This PR fixes deployment pipeline preparation by integrating token builds into the turbo pipeline.

## Changes
- Added tokens task to turbo.json pipeline
- Made build task depend on tokens for fresh generation
- Added tokens script to tokens package for turbo compatibility

## Benefits
- Prevents stale design tokens during deployment
- Ensures consistent token builds across all environments
- Integrates with existing CI/CD pipeline

Generated with [Claude Code](https://claude.ai/code)